### PR TITLE
fix: correct debug image path in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ you can start exercise of solving problem.
 - Tests grouped under `/tests` folder.
 
 <p align="center">
-  <img src="assets/debug-mode-yourself" width="600" alt="debug mode">
+  <img src="assets/debug-mode-yourself.jpg" width="600" alt="debug mode">
 </p>
 
 


### PR DESCRIPTION
## Summary
- Added missing `.jpg` extension to the debug image reference in `readme.md` (`assets/debug-mode-yourself` → `assets/debug-mode-yourself.jpg`)

## Test plan
- [x] Verify the debug mode image renders correctly in the README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)